### PR TITLE
Camera calibration/add no gui option

### DIFF
--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -132,14 +132,11 @@ def main():
     group.add_option("--max-chessboard-speed", type="float", default=-1.0,
                      help="Do not use samples where the calibration pattern is moving faster \
                      than this speed in px/frame. Set to eg. 0.5 for rolling shutter cameras.")
-    parser.add_option("-g", "--no-gui",
-                     action="store_true", default=False,
-                     help="Do not use OpenCV GUI")
-    parser.add_option("--no-mono-if-stereo",
-                     action="store_true", default=False,
-                     help="Do not calibrate also Mono even if only Stereo is asked (new intrinsics for both cameras)")
-
     parser.add_option_group(group)
+    parser.add_option("--no-gui", action="store_true", default=False,
+                      help="Do not use OpenCV GUI")
+    parser.add_option("--no-mono-if-stereo", action="store_true", default=False,
+                      help="Skip Mono calibration if asked for Stereo calibration")
 
     options, args = parser.parse_args()
 
@@ -227,8 +224,8 @@ def main():
 
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, fisheye_calib_flags, pattern, options.camera_name,
-                                checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
-                                queue_size=options.queue_size, no_gui=options.no_gui, no_mono_if_stereo=options.no_mono_if_stereo)
+                                 checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
+                                 queue_size=options.queue_size, no_gui=options.no_gui, no_mono_if_stereo=options.no_mono_if_stereo)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/nodes/cameracalibrator.py
+++ b/camera_calibration/nodes/cameracalibrator.py
@@ -132,6 +132,12 @@ def main():
     group.add_option("--max-chessboard-speed", type="float", default=-1.0,
                      help="Do not use samples where the calibration pattern is moving faster \
                      than this speed in px/frame. Set to eg. 0.5 for rolling shutter cameras.")
+    parser.add_option("-g", "--no-gui",
+                     action="store_true", default=False,
+                     help="Do not use OpenCV GUI")
+    parser.add_option("--no-mono-if-stereo",
+                     action="store_true", default=False,
+                     help="Do not calibrate also Mono even if only Stereo is asked (new intrinsics for both cameras)")
 
     parser.add_option_group(group)
 
@@ -221,8 +227,8 @@ def main():
 
     rospy.init_node('cameracalibrator')
     node = OpenCVCalibrationNode(boards, options.service_check, sync, calib_flags, fisheye_calib_flags, pattern, options.camera_name,
-                                 checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
-                                 queue_size=options.queue_size)
+                                checkerboard_flags=checkerboard_flags, max_chessboard_speed=options.max_chessboard_speed,
+                                queue_size=options.queue_size, no_gui=options.no_gui, no_mono_if_stereo=options.no_mono_if_stereo)
     rospy.spin()
 
 if __name__ == "__main__":

--- a/camera_calibration/package.xml
+++ b/camera_calibration/package.xml
@@ -20,6 +20,8 @@
   <run_depend>rospy</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  
+  <exec_depend>python_orocos_kdl</exec_depend>
 
   <license>BSD</license>
   <url>http://www.ros.org/wiki/camera_calibration</url>

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -707,6 +707,7 @@ class StereoDrawable(ImageDrawable):
         self.rscrib = None
         self.epierror = -1
         self.dim = -1
+        self.good_sample = False
 
 
 class MonoCalibrator(Calibrator):
@@ -1333,6 +1334,7 @@ class StereoCalibrator(Calibrator):
         lgray = self.mkgray(lmsg)
         rgray = self.mkgray(rmsg)
         epierror = -1
+        good_sample = False
 
         # Get display-images-to-be and detections of the calibration target
         lscrib_mono, lcorners, ldownsampled_corners, lids, lboard, (x_scale, y_scale) = self.downsample_and_detect(lgray)
@@ -1385,6 +1387,7 @@ class StereoCalibrator(Calibrator):
             if lcorners is not None and rcorners is not None and len(lcorners) == len(rcorners):
                 params = self.get_parameters(lcorners, lids, lboard, (lgray.shape[1], lgray.shape[0]))
                 if self.is_good_sample(params, lcorners, lids, self.last_frame_corners, self.last_frame_ids):
+                    good_sample = True
                     self.db.append( (params, lgray, rgray) )
                     self.good_corners.append( (lcorners, rcorners, lids, rids, lboard) )
                     print(("*** Added sample %d, p_x = %.3f, p_y = %.3f, p_size = %.3f, skew = %.3f" % tuple([len(self.db)] + params)))
@@ -1396,6 +1399,7 @@ class StereoCalibrator(Calibrator):
         rv.rscrib = rscrib
         rv.params = self.compute_goodenough()
         rv.epierror = epierror
+        rv.good_sample = good_sample
         return rv
 
     def do_calibration(self, dump = False):

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -699,6 +699,7 @@ class MonoDrawable(ImageDrawable):
         ImageDrawable.__init__(self)
         self.scrib = None
         self.linear_error = -1.0
+        self.good_sample = False
 
 class StereoDrawable(ImageDrawable):
     def __init__(self):
@@ -947,6 +948,7 @@ class MonoCalibrator(Calibrator):
         """
         gray = self.mkgray(msg)
         linear_error = -1
+        good_sample = False
 
         # Get display-image-to-be (scrib) and detection of the calibration target
         scrib_mono, corners, downsampled_corners, ids, board, (x_scale, y_scale) = self.downsample_and_detect(gray)
@@ -985,6 +987,7 @@ class MonoCalibrator(Calibrator):
                 params = self.get_parameters(corners, ids, board, (gray.shape[1], gray.shape[0]))
                 if self.is_good_sample(params, corners, ids, self.last_frame_corners, self.last_frame_ids):
                     self.db.append((params, gray))
+                    good_sample = True
                     if self.pattern == Patterns.ChArUco:
                         self.good_corners.append((corners, ids, board))
                     else:
@@ -997,6 +1000,7 @@ class MonoCalibrator(Calibrator):
         rv.scrib = scrib
         rv.params = self.compute_goodenough()
         rv.linear_error = linear_error
+        rv.good_sample = good_sample
         return rv
 
     def do_calibration(self, dump = False):

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -1269,8 +1269,8 @@ class StereoCalibrator(Calibrator):
                            self.R[2][0], self.R[2][1], self.R[2][2])
                            
         return (f"Extrinsic transformation from the right camera to the left camera:\nT = "
-                "{str(numpy.ravel(self.T).tolist())} \nR = {str(numpy.ravel(self.R).tolist())}"
-                "\nquaternion = {str(list(r.GetQuaternion()))}\nRPY = {str(list(r.GetRPY()))}")
+                f"{str(numpy.ravel(self.T).tolist())} \nR = {str(numpy.ravel(self.R).tolist())}"
+                f"\nquaternion = {str(list(r.GetQuaternion()))}\nRPY = {str(list(r.GetRPY()))}")
 
     def ost(self):
         return (self.lrost(self.name + "/left", self.l.distortion, self.l.intrinsics, self.l.R, self.l.P, self.size) +

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -39,11 +39,11 @@ import image_geometry
 import math
 import numpy.linalg
 import pickle
+import PyKDL
 import random
 import sensor_msgs.msg
 import tarfile
 import time
-import PyKDL
 from distutils.version import LooseVersion
 import sys
 from enum import Enum
@@ -1112,7 +1112,11 @@ class StereoCalibrator(Calibrator):
         return good
 
     def cal_fromcorners(self, good):
-        
+        """
+        Perform Stereo Calibration
+        Skip Mono calibration if param (no_mono_if_stereo) is set
+        :param good: list of good corners detected in both left and right images
+        """
         lcorners = [(lco, lid, b) for (lco, rco, lid, rid, b) in good]
         rcorners = [(rco, rid, b) for (lco, rco, lid, rid, b) in good]
 
@@ -1263,9 +1267,10 @@ class StereoCalibrator(Calibrator):
         r = PyKDL.Rotation(self.R[0][0], self.R[0][1], self.R[0][2],
                            self.R[1][0], self.R[1][1], self.R[1][2],
                            self.R[2][0], self.R[2][1], self.R[2][2])
-        return("Extrinsic transformation from the right camera to the left camera:\nT = "
-                +str(numpy.ravel(self.T).tolist())+"\nR = "+str(numpy.ravel(self.R).tolist())
-                +"\nquaternion = "+str(list(r.GetQuaternion()))+"\nRPY = "+str(list(r.GetRPY())))
+                           
+        return (f"Extrinsic transformation from the right camera to the left camera:\nT = "
+                "{str(numpy.ravel(self.T).tolist())} \nR = {str(numpy.ravel(self.R).tolist())}"
+                "\nquaternion = {str(list(r.GetQuaternion()))}\nRPY = {str(list(r.GetRPY()))}")
 
     def ost(self):
         return (self.lrost(self.name + "/left", self.l.distortion, self.l.intrinsics, self.l.R, self.l.P, self.size) +

--- a/camera_calibration/src/camera_calibration/calibrator.py
+++ b/camera_calibration/src/camera_calibration/calibrator.py
@@ -1143,21 +1143,21 @@ class StereoCalibrator(Calibrator):
             print("stereo pinhole calibration...")
             if LooseVersion(cv2.__version__).version[0] == 2:
                 ret = cv2.stereoCalibrate(opts, lipts, ripts, self.size,
-                                   self.l.intrinsics, self.l.distortion,
-                                   self.r.intrinsics, self.r.distortion,
-                                   self.R,                            # R
-                                   self.T,                            # T
-                                   criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 1, 1e-5),
-                                   flags = flags)
+                                          self.l.intrinsics, self.l.distortion,
+                                          self.r.intrinsics, self.r.distortion,
+                                          self.R,                            # R
+                                          self.T,                            # T
+                                          criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 1, 1e-5),
+                                          flags = flags)
             else:
                 ret = cv2.stereoCalibrate(opts, lipts, ripts,
-                                   self.l.intrinsics, self.l.distortion,
-                                   self.r.intrinsics, self.r.distortion,
-                                   self.size,
-                                   self.R,                            # R
-                                   self.T,                            # T
-                                   criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 1, 1e-5),
-                                   flags = flags)
+                                          self.l.intrinsics, self.l.distortion,
+                                          self.r.intrinsics, self.r.distortion,
+                                          self.size,
+                                          self.R,                            # R
+                                          self.T,                            # T
+                                          criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 1, 1e-5),
+                                          flags = flags)
         elif self.camera_model == CAMERA_MODEL.FISHEYE:
             print("stereo fisheye calibration...")
             if LooseVersion(cv2.__version__).version[0] == 2:
@@ -1173,13 +1173,13 @@ class StereoCalibrator(Calibrator):
                 opts = opts64
 
                 ret = cv2.fisheye.stereoCalibrate(opts, lipts, ripts,
-                                   self.l.intrinsics, self.l.distortion,
-                                   self.r.intrinsics, self.r.distortion,
-                                   self.size,
-                                   self.R,                            # R
-                                   self.T,                            # T
-                                   criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 1, 1e-5), # 30, 1e-6
-                                   flags = flags)
+                                                  self.l.intrinsics, self.l.distortion,
+                                                  self.r.intrinsics, self.r.distortion,
+                                                  self.size,
+                                                  self.R,                            # R
+                                                  self.T,                            # T
+                                                  criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 1, 1e-5), # 30, 1e-6
+                                                  flags = flags)
 
         self.set_alpha(0.0)
         rms = ret[0]

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -473,8 +473,9 @@ class OpenCVCalibrationNode(CalibrationNode):
             do_calibrate=self.ask_yes_no_question("Current collected set of samples is good enough, do you want to calibrate?")
             if do_calibrate:
                 print("**** Calibrating ****")
-                self.c.do_calibration()
+                rms = self.c.do_calibration()
                 if self.c.calibrated:
+                    print("RMS Error from this calibration is: {}".format(str(rms)))
                     do_save=self.ask_yes_no_question("Do you want to save this result and exit? If no then collecting new samples.")
                     if do_save:
                         self.c.do_save()

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -244,11 +244,11 @@ class CalibrationNode:
             if self._camera_name:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._fisheye_calib_flags, self._pattern, name=self._camera_name,
                                           checkerboard_flags=self._checkerboard_flags,
-                                          max_chessboard_speed = self._max_chessboard_speed, no_mono_if_stereo=self._no_mono_if_stereo)
+                                          max_chessboard_speed=self._max_chessboard_speed, no_mono_if_stereo=self._no_mono_if_stereo)
             else:
                 self.c = StereoCalibrator(self._boards, self._calib_flags, self._fisheye_calib_flags, self._pattern,
                                           checkerboard_flags=self._checkerboard_flags,
-                                          max_chessboard_speed = self._max_chessboard_speed, no_mono_if_stereo=self._no_mono_if_stereo)
+                                          max_chessboard_speed=self._max_chessboard_speed, no_mono_if_stereo=self._no_mono_if_stereo)
             if self._no_mono_if_stereo:
                 self.c.from_message((self.left_camera_info_msg, self.right_camera_info_msg))
 
@@ -454,14 +454,14 @@ class OpenCVCalibrationNode(CalibrationNode):
 
     def ask_for_calibration(self):
         if self.c.goodenough:
-            do_calibrate = ask_yes_no_question("Current collected set of samples"
+            do_calibrate = ask_yes_no_question("Current collected set of samples "
                                                "is good enough, do you want to calibrate?")
             if do_calibrate:
                 print("**** Calibrating ****")
                 rms = self.c.do_calibration()
                 if self.c.calibrated:
                     print("RMS Error from this calibration is: {}".format(str(rms)))
-                    do_save = ask_yes_no_question("Do you want to save this result and exit?"
+                    do_save = ask_yes_no_question("Do you want to save this result and exit? "
                                                   "If no then collecting new samples.")
                     if do_save:
                         self.c.do_save()
@@ -470,7 +470,7 @@ class OpenCVCalibrationNode(CalibrationNode):
             print("Continuing with collecting new samples...")
 
 
-def ask_yes_no_question(self, question, default_yes=True):
+def ask_yes_no_question(question, default_yes=True):
     """
     Ask the user a question via a command line prompt.
     The user should answer, y, yes, n, no or some upper-/lowercase

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -488,6 +488,3 @@ def ask_yes_no_question(question, default_yes=True):
             return False
         elif answer == "":
             return default_yes
-        else:
-            print("Please answer using only y or n (or yes/no if you prefer)")
-

--- a/camera_calibration/src/camera_calibration/camera_calibrator.py
+++ b/camera_calibration/src/camera_calibration/camera_calibrator.py
@@ -232,6 +232,8 @@ class CalibrationNode:
             self.redraw_monocular(drawable)
         else:
             self.lpub.publish(self.bridge.cv2_to_imgmsg(drawable.scrib, "bgr8"))
+            if drawable.good_sample:
+                self.queue_terminal.put(True)
 
     def handle_stereo(self, msg):
         if self.c == None:
@@ -473,7 +475,7 @@ class OpenCVCalibrationNode(CalibrationNode):
                 print("**** Calibrating ****")
                 self.c.do_calibration()
                 if self.c.calibrated:
-                    do_save=self.ask_yes_no_question("Do you want to save this result?")
+                    do_save=self.ask_yes_no_question("Do you want to save this result and exit? If no then collecting new samples.")
                     if do_save:
                         self.c.do_save()
                         rospy.signal_shutdown('Quit')


### PR DESCRIPTION
This PR adds the option to perform mono and stereo calibration without launching the GUI.
Instead, it runs the terminal yes/no questionnaire. This can be enabled with **--no-gui** flag.
To enable debugging, detection images are published on two new image topics and can be visualized in RViz.
Also **--no-mono-if-stereo** flag enables loading of intrinsic camera parameters from the CameraInfo topic and skipping the Mono camera calibration when Stereo calibration is asked to be performed.

Saving of the result od performed stereo calibration, resulting **transformation.txt** has been added in which resulting extrinsic transformation from the right to the left camera is being stored in all possible forms (translation, rotation matrix, quaternion and rpy)